### PR TITLE
Add encryption support for file operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ xcuserdata/
 
 # Specific to this project
 #
-build/*
+build/
+dbug/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,13 +8,33 @@
             "name": "(gdb) Launch",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/ue",
+            "program": "${workspaceFolder}/dbug/ue",
             "args": [],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}/dbug",
             "environment": [],
             "externalConsole": true,
             "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "debug-build"
+        },
+        {
+            "name": "(lldb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/dbug/ue",
+            "args": ["--enc", "foo"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/dbug",
+            "environment": [],
+            "externalConsole": true,
+            "MIMode": "lldb",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Cross platform Makefile
 #
 
-TARGETS = all build clean install debug
+TARGETS = all clean install debug
 
 $(TARGETS):
 	make -f Makefile.`uname` $@

--- a/Makefile.Darwin
+++ b/Makefile.Darwin
@@ -1,17 +1,24 @@
 #
 # Stupid simple makefile
 #
+SRC = $(wildcard src/*.c)
+HEADERS = $(wildcard src/*.hpp) $(wildcard src/*.h)
+
 all: build/ue
-build/ue build:
+
+build/ue: $(SRC) $(HEADERS)
 	mkdir -p build
 	cc -o build/ue src/main.c
 
 clean:
-	rm -rf build/*
+	rm -rf build
+	rm -rf dbug
 
 install: build/ue
 	cp build/ue /usr/local/bin
 
- debug debug/ue:
-	mkdir -p debug
-	cc -g -o debug/ue src/main.c
+debug: dbug/ue
+
+dbug/ue: $(SRC) $(HEADERS)
+	mkdir -p dbug
+	cc -g -o dbug/ue src/main.c

--- a/Makefile.Linux
+++ b/Makefile.Linux
@@ -1,17 +1,24 @@
 #
 # Stupid simple makefile
 #
+SRC = $(wildcard src/*.c)
+HEADERS = $(wildcard src/*.hpp) $(wildcard src/*.h)
+
 all: build/ue
-build/ue build:
+
+build/ue: $(SRC) $(HEADERS)
 	mkdir -p build
 	cc -o build/ue src/main.c
 
 clean:
-	rm -rf build/*
+	rm -rf build
+	rm -rf dbug
 
 install: build/ue
 	cp build/ue /usr/local/bin
 
- debug debug/ue:
-	mkdir -p debug
-	cc -g -o debug/ue src/main.c
+debug: dbug/ue
+
+dbug/ue: $(SRC) $(HEADERS)
+	mkdir -p dbug
+	cc -g -o dbug/ue src/main.c

--- a/src/def.h
+++ b/src/def.h
@@ -316,10 +316,4 @@ extern	int nmsg;
 extern	int	curmsgf;
 extern	int	newmsgf;
 extern	char    msg[];
-
-// Function declarations for encryption and decryption
-void encrypt_buffer(char *buffer, int length);
-void decrypt_buffer(char *buffer, int length);
-
-// Global variable to indicate if encryption is enabled
-int encrypt_flag;
+extern  int is_encrypt;

--- a/src/def.h
+++ b/src/def.h
@@ -317,3 +317,6 @@ extern	int	curmsgf;
 extern	int	newmsgf;
 extern	char    msg[];
 
+extern void encrypt_buffer(char *buf, int nbuf);
+extern void decrypt_buffer(char *buf, int nbuf);
+extern int encrypt_flag;

--- a/src/def.h
+++ b/src/def.h
@@ -317,6 +317,9 @@ extern	int	curmsgf;
 extern	int	newmsgf;
 extern	char    msg[];
 
-extern void encrypt_buffer(char *buf, int nbuf);
-extern void decrypt_buffer(char *buf, int nbuf);
-extern int encrypt_flag;
+// Function declarations for encryption and decryption
+void encrypt_buffer(char *buffer, int length);
+void decrypt_buffer(char *buffer, int length);
+
+// Global variable to indicate if encryption is enabled
+int encrypt_flag;

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -14,8 +14,6 @@
 int readin(char fname[]);
 void makename(char bname[], char fname[]);
 int writeout(char *fn);
-void encrypt_buffer(char *buffer, int length);
-void decrypt_buffer(char *buffer, int length);
 
 
 /*
@@ -376,26 +374,4 @@ filename(int f, int n, int k)
 	curbp->b_flag &= ~BFBAK;			// No backup.
 #endif
 	return (TRUE);
-}
-
-/*
-	Encrypt the buffer content using rot13.
-*/
-void encrypt_buffer(char *buffer, int length) {
-	for (int i = 0; i < length; i++) {
-		if ((buffer[i] >= 'a' && buffer[i] <= 'z') || (buffer[i] >= 'A' && buffer[i] <= 'Z')) {
-			if ((buffer[i] >= 'a' && buffer[i] <= 'm') || (buffer[i] >= 'A' && buffer[i] <= 'M')) {
-				buffer[i] += 13;
-			} else {
-				buffer[i] -= 13;
-			}
-		}
-	}
-}
-
-/*
-	Decrypt the buffer content using rot13.
-*/
-void decrypt_buffer(char *buffer, int length) {
-	encrypt_buffer(buffer, length); // rot13 is symmetric
 }

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -14,6 +14,8 @@
 int readin(char fname[]);
 void makename(char bname[], char fname[]);
 int writeout(char *fn);
+void encrypt_buffer(char *buffer, int length);
+void decrypt_buffer(char *buffer, int length);
 
 
 /*
@@ -374,4 +376,26 @@ filename(int f, int n, int k)
 	curbp->b_flag &= ~BFBAK;			// No backup.
 #endif
 	return (TRUE);
+}
+
+/*
+	Encrypt the buffer content using rot13.
+*/
+void encrypt_buffer(char *buffer, int length) {
+	for (int i = 0; i < length; i++) {
+		if ((buffer[i] >= 'a' && buffer[i] <= 'z') || (buffer[i] >= 'A' && buffer[i] <= 'Z')) {
+			if ((buffer[i] >= 'a' && buffer[i] <= 'm') || (buffer[i] >= 'A' && buffer[i] <= 'M')) {
+				buffer[i] += 13;
+			} else {
+				buffer[i] -= 13;
+			}
+		}
+	}
+}
+
+/*
+	Decrypt the buffer content using rot13.
+*/
+void decrypt_buffer(char *buffer, int length) {
+	encrypt_buffer(buffer, length); // rot13 is symmetric
 }

--- a/src/fileio.hpp
+++ b/src/fileio.hpp
@@ -26,6 +26,30 @@ void adjustcase(char *fn);
 
 static	FILE	*ffp;
 
+int offset = 'P' - '!';
+/*
+	Encrypt the buffer content using a simple rotation cipher.
+*/
+void encrypt_buffer(char *buffer, int length) {
+	for (int i = 0; i < length; i++) {
+		if (buffer[i] >= '!' && buffer[i] <= '~') {
+			if (buffer[i] >= '!' && buffer[i] <= 'O') {
+				buffer[i] += offset;
+			} else {
+				buffer[i] -= offset;
+			}
+		}
+	}
+}
+
+/*
+	Decrypt the buffer content
+*/
+void decrypt_buffer(char *buffer, int length) {
+	encrypt_buffer(buffer, length); // rotations are symmetric
+}
+
+
 /*
 	Open a file for reading.
 */
@@ -36,16 +60,6 @@ ffropen(char *fn)
 	adjustcase(fn);
 	if (ffp == NULL)
 		return (FIOFNF);
-
-	// Decrypt buffer if encryption is enabled
-	if (encrypt_flag) {
-		char buffer[NLINE];
-		int length;
-		while ((length = fread(buffer, 1, NLINE, ffp)) > 0) {
-			decrypt_buffer(buffer, length);
-		}
-		rewind(ffp);
-	}
 
 	return (FIOSUC);
 }
@@ -62,16 +76,6 @@ ffwopen(char *fn)
 	if (ffp == NULL) {
 		eprintf("Cannot open file for writing");
 		return (FIOERR);
-	}
-
-	// Encrypt buffer if encryption is enabled
-	if (encrypt_flag) {
-		char buffer[NLINE];
-		int length;
-		while ((length = fread(buffer, 1, NLINE, ffp)) > 0) {
-			encrypt_buffer(buffer, length);
-		}
-		rewind(ffp);
 	}
 
 	return (FIOSUC);
@@ -93,10 +97,15 @@ ffclose()
 	only at the newline.
 */
 int
-ffputline(char buf[], int nbuf)
+ffputline(char ibuf[], int nbuf)
 {
 	int	i;
+	char buf[NLINE];
 
+	strncpy(buf, ibuf, nbuf);
+	if (is_encrypt) {
+		encrypt_buffer(buf, nbuf);
+	}
 	for (i=0; i<nbuf; ++i)
 		putc(buf[i]&0xFF, ffp);
 	putc('\n', ffp);
@@ -152,6 +161,9 @@ ffgetline(char buf[], int nbuf)
 			return (FIOEOF);	/* no newline at EOF.	*/
 	}
 	buf[i] = 0;
+	if (is_encrypt) {
+		decrypt_buffer(buf, i);
+	}
 	return (FIOSUC);
 }
 

--- a/src/fileio.hpp
+++ b/src/fileio.hpp
@@ -16,8 +16,8 @@
 	for VMS.
  */
 #define	BDC1	'/'
-// #define BDC2	:'
-// #define BDC3	;'
+// #define BDC2	':'
+// #define BDC3	';'
 
 /*
 	Forward declarations

--- a/src/fileio.hpp
+++ b/src/fileio.hpp
@@ -16,13 +16,15 @@
 	for VMS.
  */
 #define	BDC1	'/'
-// #define BDC2	':'
-// #define BDC3 ';'
+// #define BDC2	:'
+// #define BDC3	;'
 
 /*
 	Forward declarations
 */
 void adjustcase(char *fn);
+void encrypt_buffer(char *buf, int nbuf);
+void decrypt_buffer(char *buf, int nbuf);
 
 static	FILE	*ffp;
 

--- a/src/fileio.hpp
+++ b/src/fileio.hpp
@@ -17,14 +17,12 @@
  */
 #define	BDC1	'/'
 // #define BDC2	':'
-// #define BDC3	';'
+// #define BDC3 ';'
 
 /*
 	Forward declarations
 */
 void adjustcase(char *fn);
-void encrypt_buffer(char *buf, int nbuf);
-void decrypt_buffer(char *buf, int nbuf);
 
 static	FILE	*ffp;
 
@@ -38,6 +36,17 @@ ffropen(char *fn)
 	adjustcase(fn);
 	if (ffp == NULL)
 		return (FIOFNF);
+
+	// Decrypt buffer if encryption is enabled
+	if (encrypt_flag) {
+		char buffer[NLINE];
+		int length;
+		while ((length = fread(buffer, 1, NLINE, ffp)) > 0) {
+			decrypt_buffer(buffer, length);
+		}
+		rewind(ffp);
+	}
+
 	return (FIOSUC);
 }
 
@@ -54,6 +63,17 @@ ffwopen(char *fn)
 		eprintf("Cannot open file for writing");
 		return (FIOERR);
 	}
+
+	// Encrypt buffer if encryption is enabled
+	if (encrypt_flag) {
+		char buffer[NLINE];
+		int length;
+		while ((length = fread(buffer, 1, NLINE, ffp)) > 0) {
+			encrypt_buffer(buffer, length);
+		}
+		rewind(ffp);
+	}
+
 	return (FIOSUC);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -65,7 +65,7 @@ short	*kbdmop;			/* Output for above		*/
 char	pat[NPAT];			/* Pattern			*/
 SYMBOL	*symbol[NSHASH];		/* Symbol table listhead.	*/
 SYMBOL	*binding[NKEYS];		/* Key bindings.		*/
-int encrypt_flag = 0; // Global variable to indicate if encryption is enabled
+int is_encrypt = 0; // Global variable to indicate if encryption is enabled
 
 int main(int argc, char *argv[])
 {
@@ -74,24 +74,30 @@ int main(int argc, char *argv[])
 	int	n;
 	int	mflag;
 	char		bname[NBUFN];
+	int first_file_index = 0;
 
 	strcpy(bname, "main");			/* Get buffer name.	*/
-	if (argc > 1)
-		makename(bname, argv[1]);
-	vtinit();				/* Virtual terminal.	*/
-	edinit(bname);				/* Buffers, windows.	*/
-	keymapinit();				/* Symbols, bindings.	*/
 
 	// Parse CLI options to set encrypt_flag if --enc or --encrypt is given
 	for (int i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--enc") == 0 || strcmp(argv[i], "--encrypt") == 0) {
-			encrypt_flag = 1;
+			is_encrypt = 1;
+		}
+		else if (first_file_index == 0 && argv[i][0] != '-') {
+			first_file_index = i;
 		}
 	}
 
-	if (argc > 1) {
+	if (first_file_index > 0)
+		makename(bname, argv[first_file_index]);
+	vtinit();				/* Virtual terminal.	*/
+	edinit(bname);				/* Buffers, windows.	*/
+	keymapinit();				/* Symbols, bindings.	*/
+
+
+	if (first_file_index > 0) {
 		update();
-		readin(argv[1]);
+		readin(argv[first_file_index]);
 	}
 	lastflag = 0;				/* Fake last flags.	*/
 loop:

--- a/src/main.c
+++ b/src/main.c
@@ -65,6 +65,7 @@ short	*kbdmop;			/* Output for above		*/
 char	pat[NPAT];			/* Pattern			*/
 SYMBOL	*symbol[NSHASH];		/* Symbol table listhead.	*/
 SYMBOL	*binding[NKEYS];		/* Key bindings.		*/
+int encrypt_flag = 0; // Global variable to indicate if encryption is enabled
 
 int main(int argc, char *argv[])
 {
@@ -75,14 +76,21 @@ int main(int argc, char *argv[])
 	char		bname[NBUFN];
 
 	strcpy(bname, "main");			/* Get buffer name.	*/
-	if (argc > 1)
-		makename(bname, argv[1]);
+	for (int i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "--enc") == 0 || strcmp(argv[i], "--encrypt") == 0) {
+			encrypt_flag = 1;
+		} else {
+			makename(bname, argv[i]);
+		}
+	}
 	vtinit();				/* Virtual terminal.	*/
 	edinit(bname);				/* Buffers, windows.	*/
 	keymapinit();				/* Symbols, bindings.	*/
-	if (argc > 1) {
-		update();
-		readin(argv[1]);
+	for (int i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "--enc") != 0 && strcmp(argv[i], "--encrypt") != 0) {
+			update();
+			readin(argv[i]);
+		}
 	}
 	lastflag = 0;				/* Fake last flags.	*/
 loop:

--- a/src/main.c
+++ b/src/main.c
@@ -76,21 +76,22 @@ int main(int argc, char *argv[])
 	char		bname[NBUFN];
 
 	strcpy(bname, "main");			/* Get buffer name.	*/
-	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "--enc") == 0 || strcmp(argv[i], "--encrypt") == 0) {
-			encrypt_flag = 1;
-		} else {
-			makename(bname, argv[i]);
-		}
-	}
+	if (argc > 1)
+		makename(bname, argv[1]);
 	vtinit();				/* Virtual terminal.	*/
 	edinit(bname);				/* Buffers, windows.	*/
 	keymapinit();				/* Symbols, bindings.	*/
+
+	// Parse CLI options to set encrypt_flag if --enc or --encrypt is given
 	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "--enc") != 0 && strcmp(argv[i], "--encrypt") != 0) {
-			update();
-			readin(argv[i]);
+		if (strcmp(argv[i], "--enc") == 0 || strcmp(argv[i], "--encrypt") == 0) {
+			encrypt_flag = 1;
 		}
+	}
+
+	if (argc > 1) {
+		update();
+		readin(argv[1]);
 	}
 	lastflag = 0;				/* Fake last flags.	*/
 loop:


### PR DESCRIPTION
Add support for direct editing of encrypted files using rot13 encryption.

* Add a global variable `encrypt_flag` to indicate if encryption is enabled.
* Parse CLI options to set `encrypt_flag` if `--enc` or `--encrypt` is given.
* Allow the filename and option to be given in any order.
* Modify the main function to handle the new CLI options and set the buffer name accordingly.

